### PR TITLE
wip: [Feature Request] inertial tracking using the onboard imu #21

### DIFF
--- a/src/main/main.ino
+++ b/src/main/main.ino
@@ -22,6 +22,7 @@ MPU6050 mpu;
 Relativ relativ; 
 
 #define INTERRUPT_PIN 2
+#define FRAME_RATE 50
 
 // IMU status and control:
 bool dmpReady = false;  // true if DMP init was successful
@@ -33,6 +34,13 @@ uint8_t fifoBuffer[64];
 
 
 Quaternion q;           // [w, x, y, z]
+Quaternion qf;          // filtered quaternion
+
+VectorInt16 accel;         // [x, y, z]            accel sensor measurements
+VectorInt16 omega;         // [wx, wy, wz]         gyro sensor measurements
+int last_update;
+int cycle_time;
+long last_cycle;
 
 volatile bool mpuInterrupt = false;     // indicates whether MPU interrupt pin has gone high
 void dmpDataReady() {
@@ -67,7 +75,7 @@ void setup() {
     // ==================================
     // supply your own gyro offsets here:
     // ==================================
-
+    // follow procedure here to calibrate offsets https://github.com/kkpoon/CalibrateMPU6050
     mpu.setXGyroOffset(220);
     mpu.setYGyroOffset(76);
     mpu.setZGyroOffset(-85);
@@ -127,10 +135,43 @@ void loop() {
 * like Arduino Mega, Arduino Uno, etc. (slower)
 */
 
-        relativ.updateOrientationNative(q.x, q.y, q.z, q.w, 4); 
+        // do complementary filtering here
+        mpu.dmpGetAccel(&accel, fifoBuffer);
+
+        VectorFloat16 accf(float(accel.x), float(accel.y), float(accel.z));
+
+        // find "up" direction
+        VectorFloat16 up = accf.rotate(q);
+        
+        // tilt angle is the angle made between world-y and the "up"
+        float phi = acos( up.y / up.magnitude() );
+
+        // drift due to tilt
+        Quaternion d_tilt( cos(phi/2.f), up.normalize().z * sin(phi/2.f), 0.f, -up.normalize().x * sin(phi/2.f) );
+
+        // TO DO: if magnetometer readings are available, yaw drift can be accounted for
+        // int16_t ax_tmp, ay_tmp, az_tmp, gx_tmp, gy_tmp, gz_tmp, mx, my, mz;
+        // mpu.getMotion9(ax_tmp, ay_tmp, az_tmp, gx_tmp, gy_tmp, gz_tmp, mx, my, mz);
+        // VectorFloat16 magn(float(mx), float(my), float(mz));
+        // VectorFloat16 north = magn.rotate(q);
+        // float beta = acos( -north.z / north.magnitude() );
+        // 
+
+        relativ.updateOrientationNative(q.x, q.y, q.z, q.w, 4);
 
         //If your microcontroller is non-native usb, change the above line to:
         //relativ.updateOrientation(q.x, q.y, q.z, q.w, 4); 
     }
+}
+
+// ensure regular clock-rate
+void hold_time() {
+    long time = millis();
+    while ( (time - last_cycle) < FRAME_RATE ){
+        delay(1);
+        time = millis();
+    }
+    cycle_time = time - last_cycle;
+    last_cycle = time;
 }
 

--- a/src/main/main.ino
+++ b/src/main/main.ino
@@ -22,7 +22,9 @@ MPU6050 mpu;
 Relativ relativ; 
 
 #define INTERRUPT_PIN 2
-#define FRAME_RATE 50
+// set these to correct for drift - try small values ~0.000001
+#define ALPHA 0.f // correction for drift - tilt channel
+#define BETA  0.f // correction for drift - yaw channel
 
 // IMU status and control:
 bool dmpReady = false;  // true if DMP init was successful
@@ -32,15 +34,7 @@ uint16_t packetSize;
 uint16_t fifoCount;     
 uint8_t fifoBuffer[64]; 
 
-
 Quaternion q;           // [w, x, y, z]
-Quaternion qf;          // filtered quaternion
-
-VectorInt16 accel;         // [x, y, z]            accel sensor measurements
-VectorInt16 omega;         // [wx, wy, wz]         gyro sensor measurements
-int last_update;
-int cycle_time;
-long last_cycle;
 
 volatile bool mpuInterrupt = false;     // indicates whether MPU interrupt pin has gone high
 void dmpDataReady() {
@@ -99,7 +93,6 @@ void setup() {
     }
 }
 
-
 void loop() {
     // Do nothing if DMP doesn't initialize correctly
     if (!dmpReady) return;
@@ -135,19 +128,15 @@ void loop() {
 * like Arduino Mega, Arduino Uno, etc. (slower)
 */
 
-        // do complementary filtering here
-        mpu.dmpGetAccel(&accel, fifoBuffer);
-
-        VectorFloat16 accf(float(accel.x), float(accel.y), float(accel.z));
-
-        // find "up" direction
-        VectorFloat16 up = accf.rotate(q);
+        // find direction of gravity (down in world frame)
+        VectorFloat16 down;
+        mpu.dmpGetGravity(&down, &q);
         
-        // tilt angle is the angle made between world-y and the "up"
-        float phi = acos( up.y / up.magnitude() );
+        // tilt angle is the angle made between world-y and the "up"-vector (just negative of "down")
+        float phi = acos( -down.y / down.magnitude() );
 
         // drift due to tilt
-        Quaternion d_tilt( cos(phi/2.f), up.normalize().z * sin(phi/2.f), 0.f, -up.normalize().x * sin(phi/2.f) );
+        Quaternion d_tilt( cos(phi/2.f), -down.normalize().z * sin(phi/2.f), 0.f, down.normalize().x * sin(phi/2.f) );
 
         // TO DO: if magnetometer readings are available, yaw drift can be accounted for
         // int16_t ax_tmp, ay_tmp, az_tmp, gx_tmp, gy_tmp, gz_tmp, mx, my, mz;
@@ -155,23 +144,26 @@ void loop() {
         // VectorFloat16 magn(float(mx), float(my), float(mz));
         // VectorFloat16 north = magn.rotate(q);
         // float beta = acos( -north.z / north.magnitude() );
-        // 
+        // Quaternion d_yaw( cos(beta/2.f), 0.f, sin(beta/2.f), 0.f );
+        Quaternion d_yaw; // just default to identity if no magnetometer is available.
 
-        relativ.updateOrientationNative(q.x, q.y, q.z, q.w, 4);
+        // COMPLEMENTARY FILTER (YAW CORRECTION * TILT CORRECTION * QUATERNION FROM ABOVE)
+        double tilt_correct = -ALPHA * 2.f * acos(d_tilt.w);
+        double yaw_correct  = -BETA  * 2.f * acos(d_yaw.w);
+        Quaternion tilt_correction( cos(tilt_correct/2.f), -down.normalize() * sin(tilt_correct/2.f), 0.f, down.normalize().x * sin(tilt_correct/2.f) );
+        Quaternion yaw_correction( cos(yaw_correct/2.f), 0.f, sin(yaw_correct/2.f), 0.f);
+
+        // qc = yc * tc * q
+        Quaternion qc(tilt_correction.w, tilt_correction.x, tilt_correction.y, tilt_correction.z);
+        qc.getProduct(yaw_correction);
+        qc.getProduct(tilt_correction);
+        qc.getProduct(q);
+
+        // report result
+        relativ.updateOrientationNative(qc.x, qc.y, qc.z, qc.w, 4);
 
         //If your microcontroller is non-native usb, change the above line to:
         //relativ.updateOrientation(q.x, q.y, q.z, q.w, 4); 
     }
-}
-
-// ensure regular clock-rate
-void hold_time() {
-    long time = millis();
-    while ( (time - last_cycle) < FRAME_RATE ){
-        delay(1);
-        time = millis();
-    }
-    cycle_time = time - last_cycle;
-    last_cycle = time;
 }
 


### PR DESCRIPTION
I have added a quick correction for accumulated drift errors.  Some things to consider:

- The algorithm implemented comes from http://msl.cs.uiuc.edu/vr/vrch9.pdf

- The MPU6050 appears to compensate for accumulated errors, however the algorithm can be tuned for better overall compensation (see `#define ALPHA` and `#define BETA`).

Setting `#define`'s to `0` will return the same result as is currently used (no additional compensation).